### PR TITLE
feat: encapsulated tasks

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -56,8 +56,9 @@ function createTaskFromDescriptor(desc) {
 
   const value = extractValue(desc);
   assert(
-    'ember-concurrency-decorators: Can only decorate a generator function as a task.',
-    typeof value === 'function'
+    'ember-concurrency-decorators: Can only decorate a generator function as a task or an object with a generator method `perform` as an encapsulated task.',
+    typeof value === 'function' ||
+      (typeof value === 'object' && typeof value.perform === 'function')
   );
 
   return createTaskProperty(value);

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    'ember/avoid-leaking-state-in-ember-objects': 'off'
+  }
+};

--- a/tests/unit/decorators-js-test.js
+++ b/tests/unit/decorators-js-test.js
@@ -12,38 +12,47 @@ import { module, test } from 'qunit';
 module('Unit: decorators (JS)');
 
 test('Ember object model (EmberObject.extend)', function(assert) {
-  assert.expect(5);
+  assert.expect(6);
 
   const Obj = EmberObject.extend({
     @task
-    doStuff: function * () {
+    doStuff: function*() {
       yield;
       return 123;
     },
 
     @restartableTask
-    a: function * () {
+    a: function*() {
       yield;
       return 456;
     },
 
     @keepLatestTask
-    b: function * () {
+    b: function*() {
       yield;
       return 789;
     },
 
     @dropTask
-    c: function * () {
+    c: function*() {
       yield;
       return 12;
     },
 
     @enqueueTask
-    d: function * () {
+    d: function*() {
       yield;
       return 34;
     },
+
+    @task
+    encapsulated: {
+      privateState: 56,
+      *perform() {
+        yield;
+        return this.privateState;
+      }
+    }
   });
 
   let obj;
@@ -54,46 +63,57 @@ test('Ember object model (EmberObject.extend)', function(assert) {
     obj.get('b').perform();
     obj.get('c').perform();
     obj.get('d').perform();
+    obj.get('encapsulated').perform();
   });
   assert.equal(obj.get('doStuff.last.value'), 123);
   assert.equal(obj.get('a.last.value'), 456);
   assert.equal(obj.get('b.last.value'), 789);
   assert.equal(obj.get('c.last.value'), 12);
   assert.equal(obj.get('d.last.value'), 34);
+  assert.equal(obj.get('encapsulated.last.value'), 56);
 });
 
-test('Native classes (class extends EmberObject)', function (assert) {
-  assert.expect(5);
+test('Native classes (class extends EmberObject)', function(assert) {
+  assert.expect(6);
 
   class Obj extends EmberObject {
     @task
-    doStuff = function* () {
+    doStuff = function*() {
       yield;
       return 123;
     };
 
     @restartableTask
-    a = function* () {
+    a = function*() {
       yield;
       return 456;
     };
 
     @keepLatestTask
-    b = function* () {
+    b = function*() {
       yield;
       return 789;
     };
 
     @dropTask
-    c = function* () {
+    c = function*() {
       yield;
       return 12;
     };
 
     @enqueueTask
-    d = function* () {
+    d = function*() {
       yield;
       return 34;
+    };
+
+    @task
+    encapsulated = {
+      privateState: 56,
+      *perform() {
+        yield;
+        return this.privateState;
+      }
     };
   }
 
@@ -105,10 +125,12 @@ test('Native classes (class extends EmberObject)', function (assert) {
     obj.get('b').perform();
     obj.get('c').perform();
     obj.get('d').perform();
+    obj.get('encapsulated').perform();
   });
   assert.equal(obj.get('doStuff.last.value'), 123);
   assert.equal(obj.get('a.last.value'), 456);
   assert.equal(obj.get('b.last.value'), 789);
   assert.equal(obj.get('c.last.value'), 12);
   assert.equal(obj.get('d.last.value'), 34);
+  assert.equal(obj.get('encapsulated.last.value'), 56);
 });


### PR DESCRIPTION
Closes #15 by allowing objects with a `perform` function to be decorated.

This only one possible, but really easy solution to the problem. I'd like to gather some feedback / thoughts on alternative API as outlined in https://github.com/machty/ember-concurrency-decorators/issues/15#issuecomment-428158274. 