### PR TITLE
docs(README): add badges, notes on ember-cli-babel, index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # ember-concurrency-decorators
 
+[![Build Status](https://travis-ci.org/machty/ember-concurrency-decorators.svg)](https://travis-ci.org/machty/ember-concurrency-decorators)
+[![npm version](https://badge.fury.io/js/ember-concurrency-decorators.svg)](http://badge.fury.io/js/ember-concurrency-decorators)
+[![Download Total](https://img.shields.io/npm/dt/ember-concurrency-decorators.svg)](http://badge.fury.io/js/ember-concurrency-decorators)
+[![Ember Observer Score](https://emberobserver.com/badges/ember-concurrency-decorators.svg)](https://emberobserver.com/addons/ember-concurrency-decorators)
+[![Ember Versions](https://img.shields.io/badge/Ember.js%20Versions-%5E2.12%20%7C%7C%20%5E3.0-brightgreen.svg)](https://travis-ci.org/machty/ember-concurrency-decorators)
+[![dependencies](https://img.shields.io/david/machty/ember-concurrency-decorators.svg)](https://david-dm.org/machty/ember-concurrency-decorators)
+[![devDependencies](https://img.shields.io/david/dev/machty/ember-concurrency-decorators.svg)](https://david-dm.org/machty/ember-concurrency-decorators)
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
+
+
 This Ember Addon lets you use the
 [decorator syntax](https://github.com/tc39/proposal-decorators)
 for declaring/configuring

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 
 
-This Ember Addon lets you use the
+This Ember addon lets you use the
 [decorator syntax](https://github.com/tc39/proposal-decorators)
 for declaring/configuring
 [ember-concurrency](https://ember-concurrency.com) tasks.
@@ -22,6 +22,14 @@ Then install as any other addon:
 
 ```
 ember install ember-concurrency-decorators
+```
+
+If you are _not_ using TypeScript, in order for [ember-cli-babel](https://github.com/babel/ember-cli-babel) to understand the `@decorator` syntax, you at least also need to install [`@ember-decorators/babel-transforms`](https://github.com/ember-decorators/babel-transforms). Instead of that you can also install the [`ember-decorators`](https://github.com/ember-decorators/ember-decorators) meta package:
+
+```bash
+ember install ember-decorators
+# or
+ember install @ember-decorators/babel-transforms
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ ember install @ember-decorators/babel-transforms
 
 ### Available decorators
 
+- **[`@task`](#task)**: turns a generator method into a task
+  - `@restartableTask`
+  - `@dropTask`
+  - `@keepLatestTask`
+  - `@enqueueTask`
+- **[`@taskGroup`](#taskgroup)**: creates a task group from a property
+  - `@restartableTaskGroup`
+  - `@dropTaskGroup`
+  - `@keepLatestTaskGroup`
+  - `@enqueueTaskGroup`
+- **[`@lastValue`](#lastvalue)**: alias a property to the result of a task with an optional default value
+
 #### `@task`
 
 ```js

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![Download Total](https://img.shields.io/npm/dt/ember-concurrency-decorators.svg)](http://badge.fury.io/js/ember-concurrency-decorators)
 [![Ember Observer Score](https://emberobserver.com/badges/ember-concurrency-decorators.svg)](https://emberobserver.com/addons/ember-concurrency-decorators)
 [![Ember Versions](https://img.shields.io/badge/Ember.js%20Versions-%5E2.12%20%7C%7C%20%5E3.0-brightgreen.svg)](https://travis-ci.org/machty/ember-concurrency-decorators)
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 [![dependencies](https://img.shields.io/david/machty/ember-concurrency-decorators.svg)](https://david-dm.org/machty/ember-concurrency-decorators)
 [![devDependencies](https://img.shields.io/david/dev/machty/ember-concurrency-decorators.svg)](https://david-dm.org/machty/ember-concurrency-decorators)
-[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 
 
 This Ember addon lets you use the


### PR DESCRIPTION
This makes the README a bit more colorful and proactively adds an explainer for using decorators with ember-cli-babel to avoid potential confusion.

Also adds an index of the available decorators for quick reference at a glance.