### PR TITLE
feat(lastValue): export `@lastValue` from root index

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ This decorator allows you to alias a property to the result of a task. You can a
 ```js
 import Component from '@ember/component';
 import { task } from 'ember-concurrency-decorators';
-import { lastValue } from 'ember-concurrency-decorators/last-value';
+import { lastValue } from 'ember-concurrency-decorators';
 
 export default class ExampleComponent extends Component {
   @task

--- a/addon/index.js
+++ b/addon/index.js
@@ -5,6 +5,8 @@ import {
 import { computedDecoratorWithParams } from '@ember-decorators/utils/computed';
 import { assert } from '@ember/debug';
 
+export { default as lastValue } from './last-value';
+
 /**
  * This utility function assures compatibility with the Ember object model style
  * and initializer syntax required by Babel 6.

--- a/addon/last-value.js
+++ b/addon/last-value.js
@@ -5,9 +5,9 @@ import { computedDecoratorWithParams } from '@ember-decorators/utils/computed';
  * This decorator allows you to alias a property to the result of a task. You can also provide a default value to use before the task has completed.
  *
  * ```js
- * import Component from "@ember/component";
- * import { task } from "ember-concurrency-decorators";
- * import { lastValue } from "ember-concurrency-decorators";
+ * import Component from '@ember/component';
+ * import { task } from 'ember-concurrency-decorators';
+ * import { lastValue } from 'ember-concurrency-decorators';
  *
  * export default class ExampleComponent extends Component {
  *   @task
@@ -15,11 +15,11 @@ import { computedDecoratorWithParams } from '@ember-decorators/utils/computed';
  *     // ...
  *   };
  *
- *   @lastValue("someTask")
+ *   @lastValue('someTask')
  *   someTaskValue;
  *
- *   @lastValue("someTask")
- *   someTaskValueWithDefault = "A default value";
+ *   @lastValue('someTask')
+ *   someTaskValueWithDefault = 'A default value';
  * }
  * ```
  *

--- a/addon/last-value.js
+++ b/addon/last-value.js
@@ -7,7 +7,7 @@ import { computedDecoratorWithParams } from '@ember-decorators/utils/computed';
  * ```js
  * import Component from "@ember/component";
  * import { task } from "ember-concurrency-decorators";
- * import { lastValue } from "ember-concurrency-decorators/last-value";
+ * import { lastValue } from "ember-concurrency-decorators";
  *
  * export default class ExampleComponent extends Component {
  *   @task

--- a/tests/unit/last-value-test.js
+++ b/tests/unit/last-value-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import EmberObject from '@ember/object';
 import { task } from 'ember-concurrency-decorators';
-import lastValue from 'ember-concurrency-decorators/last-value';
+import { lastValue } from 'ember-concurrency-decorators';
 import inRunLoop, {
   next as nextLoop
 } from 'ember-concurrency-decorators/test-support/in-run-loop';


### PR DESCRIPTION
@alexlafroscia Do you think we're good doing this? Was there a specific reason for not doing it like this in the first place or just by chance?

I think for potential tree shaking this would not pose a problem, because the exports are statically analyzable.

I tagged this as `feat` as opposed to `refactor`, because I've _added_ a new export.