### PR TITLE
fix(types): accept any generator method parameters

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,9 @@ type ExtractPropertyNamesOfType<T, S> = {
   [K in keyof T]: T[K] extends S ? K : never
 }[keyof T];
 
-type GeneratorFn = () => IterableIterator<any>;
+type GeneratorFn<Args extends any[] = any[]> = (
+  ...args: Args
+) => IterableIterator<any>;
 
 type TaskMethodKeys<T> = ExtractPropertyNamesOfType<T, GeneratorFn>;
 type EncapsulatedTaskKeys<T> = ExtractPropertyNamesOfType<


### PR DESCRIPTION
Fixes #31.

Thanks to @theseyi for providing the crucial hint, that it works with optional arguments, but not with required arguments. The reason is that `GeneratorFn` previously required a generator function that receives no arguments. A function with only optional arguments fulfills this  criterium.