### PR TITLE
chore(pkg): add `yarn-error.log` to `.npmignore`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -22,6 +22,7 @@
 /ember-cli-build.js
 /testem.js
 /tests/
+/yarn-error.log
 /yarn.lock
 .gitkeep
 


### PR DESCRIPTION
I noticed that the package currently published to npm (1.0.0-beta.1) includes a `yarn-error.log`. This PR tells npm to ignore that file.