### PR TITLE
chore(pkg): publish TypeScript types to npm

### DIFF
--- a/addon-test-support/in-run-loop.ts
+++ b/addon-test-support/in-run-loop.ts
@@ -5,7 +5,7 @@ import { begin, end } from '@ember/runloop';
  *
  * @param {object} hooks QUnit Hooks
  */
-export default function inRunloop(hooks) {
+export default function inRunloop(hooks: NestedHooks) {
   hooks.beforeEach(function() {
     begin();
   });

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "lint:types": "tsc",
     "start": "ember serve",
     "test": "ember test",
-    "test:all": "ember try:each"
+    "test:all": "ember try:each",
+    "prepublishOnly": "ember ts:precompile",
+    "postpublish": "ember ts:clean"
   },
   "dependencies": {
     "@ember-decorators/utils": "^6.0.0",


### PR DESCRIPTION
I noticed that this addon is using `ember-cli-typescript` but isn't publishing the type declarations to npm. I re-ran the `ember-cli-typescript` generator to add the necessary scripts to `package.json`, and fixed a compilation error resulting from TypeScript being unable to find a declaration for `addon-test-support/in-run-loop.js`. Rather than write a declaration, I figured it was easier to just convert the file to TypeScript.