### PR TITLE
[BREAKING] Upgrade TypeScript to 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,9 @@ jobs:
     - env: EMBER_TRY_SCENARIO=ember-canary
     - env: EMBER_TRY_SCENARIO=ember-default-with-jquery
     - env: EMBER_TRY_SCENARIO=ember-classic
+    - env: EMBER_TRY_SCENARIO=typescript-3.6
+    - env: EMBER_TRY_SCENARIO=typescript-3.8
+    - env: EMBER_TRY_SCENARIO=typescript-3.9
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash

--- a/addon/last-value.ts
+++ b/addon/last-value.ts
@@ -1,4 +1,4 @@
-import { decoratorWithRequiredParams } from '@ember-decorators/utils/decorator';
+import { decoratorWithRequiredParams, DecoratorDescriptor } from '@ember-decorators/utils/decorator';
 import { assert } from '@ember/debug';
 import { get, computed } from '@ember/object';
 
@@ -35,7 +35,7 @@ export default decoratorWithRequiredParams(function lastValue<
   key: keyof Target,
   desc: PropertyDescriptor & { initializer?: () => any },
   [taskName]: [string]
-) {
+): DecoratorDescriptor {
   assert(
     `ember-concurrency-decorators: @lastValue expects a task name as the first parameter.`,
     typeof taskName === 'string'

--- a/addon/last-value.ts
+++ b/addon/last-value.ts
@@ -1,4 +1,7 @@
-import { decoratorWithRequiredParams, DecoratorDescriptor } from '@ember-decorators/utils/decorator';
+import {
+  decoratorWithRequiredParams,
+  DecoratorDescriptor
+} from '@ember-decorators/utils/decorator';
 import { assert } from '@ember/debug';
 import { get, computed } from '@ember/object';
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -121,7 +121,7 @@ module.exports = async function() {
         name: 'typescript-3.6',
         npm: {
           devDependencies: {
-            'typescript': '~3.6.0'
+            typescript: '~3.6.0'
           }
         },
         command: 'tsc'
@@ -130,7 +130,7 @@ module.exports = async function() {
         name: 'typescript-3.8',
         npm: {
           devDependencies: {
-            'typescript': '~3.8.0'
+            typescript: '~3.8.0'
           }
         },
         command: 'tsc'
@@ -139,7 +139,7 @@ module.exports = async function() {
         name: 'typescript-3.9',
         npm: {
           devDependencies: {
-            'typescript': '~3.9.0'
+            typescript: '~3.9.0'
           }
         },
         command: 'tsc'

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -116,6 +116,33 @@ module.exports = async function() {
             edition: 'classic'
           }
         }
+      },
+      {
+        name: 'typescript-3.6',
+        npm: {
+          devDependencies: {
+            'typescript': '~3.6.0'
+          }
+        },
+        command: 'tsc'
+      },
+      {
+        name: 'typescript-3.8',
+        npm: {
+          devDependencies: {
+            'typescript': '~3.8.0'
+          }
+        },
+        command: 'tsc'
+      },
+      {
+        name: 'typescript-3.9',
+        npm: {
+          devDependencies: {
+            'typescript': '~3.9.0'
+          }
+        },
+        command: 'tsc'
       }
     ]
   };

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.18.2",
-    "typescript": "^3.5.3"
+    "typescript": "~3.9.5"
   },
   "engines": {
     "node": "10.* || >= 12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12136,10 +12136,10 @@ typescript-memoize@^1.0.0-alpha.3:
   dependencies:
     core-js "2.4.1"
 
-typescript@^3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
-  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
+typescript@~3.9.5:
+  version "3.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
+  integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
Upgrades TypeScript to 3.9, add 3.6, 3.8 and 3.9 to ember-try.

This matches the upcoming support matrix in machty/ember-concurrency#357

Upgrading TypeScript (a dev dependency) itself is not breaking. However, this drops TS 3.5 as a tested configuration. This is inevitable, since we will start depending on the types from upstream instead of vendoring our own, and the upstream types does not support 3.5.

in comparison even more breaking than this change, so it shouldn't be an issue to drop 3.5 here.
