### PR TITLE
Allow `task` to work as a "pass-through" wrapper for TS support

### DIFF
--- a/addon/index.ts
+++ b/addon/index.ts
@@ -4,6 +4,7 @@ import {
 } from '@ember-decorators/utils/decorator';
 import { assert } from '@ember/debug';
 import EmberObject from '@ember/object';
+import ComputedProperty from '@ember/object/computed';
 
 import {
   task as createTaskProperty,
@@ -258,14 +259,18 @@ export function task(options: TaskOptions): PropertyDecorator;
 // TODO: remove & EmberObject when https://github.com/machty/ember-concurrency/pull/363 lands
 export function task<T extends TaskFunction>(
   taskFn: T
-): Task<TaskFunctionReturnType<T>, TaskFunctionArgs<T>> & EmberObject;
+): ComputedProperty<
+  Task<TaskFunctionReturnType<T>, TaskFunctionArgs<T>> & EmberObject
+>;
 export function task<T extends EncapsulatedTask>(
   taskFn: T
-): Task<
-  EncapsulatedTaskDescriptorReturnType<T>,
-  EncapsulatedTaskDescriptorArgs<T>
-> &
-  EmberObject;
+): ComputedProperty<
+  Task<
+    EncapsulatedTaskDescriptorReturnType<T>,
+    EncapsulatedTaskDescriptorArgs<T>
+  > &
+    EmberObject
+>;
 export function task(
   ...args:
     | [object, string | symbol]

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -3,6 +3,7 @@ import {
   DecoratorDescriptor
 } from '@ember-decorators/utils/decorator';
 import { assert } from '@ember/debug';
+import EmberObject from '@ember/object';
 
 import {
   task as createTaskProperty,
@@ -254,15 +255,17 @@ const taskDecorator = createDecorator(createTaskFromDescriptor);
  */
 export function task(target: object, propertyKey: string | symbol): void;
 export function task(options: TaskOptions): PropertyDecorator;
+// TODO: remove & EmberObject when https://github.com/machty/ember-concurrency/pull/363 lands
 export function task<T extends TaskFunction>(
   taskFn: T
-): Task<TaskFunctionReturnType<T>, TaskFunctionArgs<T>>;
+): Task<TaskFunctionReturnType<T>, TaskFunctionArgs<T>> & EmberObject;
 export function task<T extends EncapsulatedTask>(
   taskFn: T
 ): Task<
   EncapsulatedTaskDescriptorReturnType<T>,
   EncapsulatedTaskDescriptorArgs<T>
->;
+> &
+  EmberObject;
 export function task(
   ...args:
     | [object, string | symbol]

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -150,19 +150,19 @@ function createTaskGroupFromDescriptor(
  */
 function applyOptions(
   options: TaskGroupOptions,
-  task: TaskGroupProperty
+  taskProperty: TaskGroupProperty
 ): TaskGroupProperty & Decorator;
 function applyOptions(
   options: TaskOptions,
-  task: TaskProperty
+  taskProperty: TaskProperty
 ): TaskProperty & Decorator;
 function applyOptions(
   options: TaskGroupOptions | TaskOptions,
-  task: TaskGroupProperty | TaskProperty
+  taskProperty: TaskGroupProperty | TaskProperty
 ): (TaskGroupProperty | TaskProperty) & Decorator {
   return Object.entries(options).reduce(
     (
-      taskProperty,
+      optionTaskProperty,
       [key, value]: [
         keyof typeof options,
         ObjectValues<Required<typeof options>>
@@ -170,18 +170,18 @@ function applyOptions(
     ) => {
       assert(
         `ember-concurrency-decorators: Option '${key}' is not a valid function`,
-        typeof taskProperty[key] === 'function'
+        typeof optionTaskProperty[key] === 'function'
       );
       if (value === true) {
-        return (taskProperty[key] as () => typeof taskProperty)();
+        return (optionTaskProperty[key] as () => typeof optionTaskProperty)();
       }
-      return (taskProperty[key] as (o: typeof value) => typeof taskProperty)(
-        value
-      );
+      return (optionTaskProperty[key] as (
+        o: typeof value
+      ) => typeof optionTaskProperty)(value);
     },
-    task
+    taskProperty
     // The CP decorator gets executed in `createDecorator`
-  ) as typeof task & Decorator;
+  ) as typeof taskProperty & Decorator;
 }
 
 type MethodOrPropertyDecoratorWithParams<

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -279,13 +279,11 @@ export function task(
     | [TaskFunction]
     | [EncapsulatedTask]
 ):
+  | PropertyDecorator // needed for overload compatibility
   | TaskFunction
   | EncapsulatedTask
   | PropertyDescriptor
-  | void
-  // It doesn't *actuallly* ever return these, but they're needed for compatibility with the overloads.
-  | PropertyDecorator
-  | Task<unknown, unknown[]> {
+  | void {
   const [argument1, argument2, argument3] = args;
   if (isTaskFunction(argument1) || isEncapsulatedTask(argument1)) {
     return argument1;

--- a/tests/unit/decorators-test.ts
+++ b/tests/unit/decorators-test.ts
@@ -76,6 +76,57 @@ module('Unit | decorators', function() {
     assert.equal(subject.get('d.last.value'), 34);
   });
 
+  test('Basic decorators functionality (using wrapper for TS support)', function(assert) {
+    assert.expect(5);
+
+    class TestSubject extends EmberObject {
+      @task
+      doStuff = task(function*() {
+        yield;
+        return 123;
+      });
+
+      @restartableTask
+      a = task(function*() {
+        yield;
+        return 456;
+      });
+
+      @keepLatestTask
+      b = task(function*() {
+        yield;
+        return 789;
+      });
+
+      @dropTask
+      c = task(function*() {
+        yield;
+        return 12;
+      });
+
+      @enqueueTask
+      d = task(function*() {
+        yield;
+        return 34;
+      });
+    }
+
+    let subject!: TestSubject;
+    run(() => {
+      subject = TestSubject.create();
+      subject.get('doStuff').perform();
+      subject.get('a').perform();
+      subject.get('b').perform();
+      subject.get('c').perform();
+      subject.get('d').perform();
+    });
+    assert.equal(subject.get('doStuff').last?.value, 123);
+    assert.equal(subject.get('a').last?.value, 456);
+    assert.equal(subject.get('b').last?.value, 789);
+    assert.equal(subject.get('c').last?.value, 12);
+    assert.equal(subject.get('d').last?.value, 34);
+  });
+
   // This has actually never worked.
   test('Encapsulated tasks', function(assert) {
     assert.expect(1);
@@ -98,5 +149,29 @@ module('Unit | decorators', function() {
     });
     // @ts-ignore
     assert.equal(subject.get('encapsulated.last.value'), 56);
+  });
+
+  test('Encapsulated tasks (using wrapper for TS support)', function(assert) {
+    assert.expect(1);
+
+    const ENCAPSULATED_TASK = {
+      privateState: 56,
+      *perform() {
+        yield;
+        return this.privateState;
+      }
+    };
+
+    class TestSubject extends EmberObject {
+      @task
+      encapsulated = task(ENCAPSULATED_TASK);
+    }
+
+    let subject!: TestSubject;
+    run(() => {
+      subject = TestSubject.create();
+      subject.get('encapsulated').perform();
+    });
+    assert.equal(subject.get('encapsulated').last?.value, 56);
   });
 });

--- a/tests/unit/decorators-test.ts
+++ b/tests/unit/decorators-test.ts
@@ -1,10 +1,11 @@
 /* eslint-disable max-classes-per-file */
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* eslint-disable @typescript-eslint/ban-ts-ignore */
 
 import { module, test } from 'qunit';
 
 import EmberObject from '@ember/object';
 import { run } from '@ember/runloop';
+import Ember from 'ember';
 
 import {
   task,
@@ -120,11 +121,26 @@ module('Unit | decorators', function() {
       subject.get('c').perform();
       subject.get('d').perform();
     });
-    assert.equal(subject.get('doStuff').last?.value, 123);
-    assert.equal(subject.get('a').last?.value, 456);
-    assert.equal(subject.get('b').last?.value, 789);
-    assert.equal(subject.get('c').last?.value, 12);
-    assert.equal(subject.get('d').last?.value, 34);
+    // eslint-disable-next-line ember/new-module-imports
+    if (/^2\./.test(Ember.VERSION)) {
+      // Have access computed properties with .get w/ Ember 2.x
+      // @ts-ignore
+      assert.equal(subject.get('doStuff.last.value'), 123);
+      // @ts-ignore
+      assert.equal(subject.get('a.last.value'), 456);
+      // @ts-ignore
+      assert.equal(subject.get('b.last.value'), 789);
+      // @ts-ignore
+      assert.equal(subject.get('c.last.value'), 12);
+      // @ts-ignore
+      assert.equal(subject.get('d.last.value'), 34);
+    } else {
+      assert.equal(subject.get('doStuff').last?.value, 123);
+      assert.equal(subject.get('a').last?.value, 456);
+      assert.equal(subject.get('b').last?.value, 789);
+      assert.equal(subject.get('c').last?.value, 12);
+      assert.equal(subject.get('d').last?.value, 34);
+    }
   });
 
   // This has actually never worked.
@@ -172,6 +188,12 @@ module('Unit | decorators', function() {
       subject = TestSubject.create();
       subject.get('encapsulated').perform();
     });
-    assert.equal(subject.get('encapsulated').last?.value, 56);
+    // eslint-disable-next-line ember/new-module-imports
+    if (/^2\./.test(Ember.VERSION)) {
+      // @ts-ignore
+      assert.equal(subject.get('encapsulated.last.value'), 56);
+    } else {
+      assert.equal(subject.get('encapsulated').last?.value, 56);
+    }
   });
 });

--- a/tests/unit/decorators-test.ts
+++ b/tests/unit/decorators-test.ts
@@ -5,7 +5,6 @@ import { module, test } from 'qunit';
 
 import EmberObject from '@ember/object';
 import { run } from '@ember/runloop';
-import Ember from 'ember';
 
 import {
   task,
@@ -121,26 +120,11 @@ module('Unit | decorators', function() {
       subject.get('c').perform();
       subject.get('d').perform();
     });
-    // eslint-disable-next-line ember/new-module-imports
-    if (/^2\./.test(Ember.VERSION)) {
-      // Have access computed properties with .get w/ Ember 2.x
-      // @ts-ignore
-      assert.equal(subject.get('doStuff.last.value'), 123);
-      // @ts-ignore
-      assert.equal(subject.get('a.last.value'), 456);
-      // @ts-ignore
-      assert.equal(subject.get('b.last.value'), 789);
-      // @ts-ignore
-      assert.equal(subject.get('c.last.value'), 12);
-      // @ts-ignore
-      assert.equal(subject.get('d.last.value'), 34);
-    } else {
-      assert.equal(subject.get('doStuff').last?.value, 123);
-      assert.equal(subject.get('a').last?.value, 456);
-      assert.equal(subject.get('b').last?.value, 789);
-      assert.equal(subject.get('c').last?.value, 12);
-      assert.equal(subject.get('d').last?.value, 34);
-    }
+    assert.equal(subject.get('doStuff').get('last')?.value, 123);
+    assert.equal(subject.get('a').get('last')?.value, 456);
+    assert.equal(subject.get('b').get('last')?.value, 789);
+    assert.equal(subject.get('c').get('last')?.value, 12);
+    assert.equal(subject.get('d').get('last')?.value, 34);
   });
 
   // This has actually never worked.
@@ -188,12 +172,6 @@ module('Unit | decorators', function() {
       subject = TestSubject.create();
       subject.get('encapsulated').perform();
     });
-    // eslint-disable-next-line ember/new-module-imports
-    if (/^2\./.test(Ember.VERSION)) {
-      // @ts-ignore
-      assert.equal(subject.get('encapsulated.last.value'), 56);
-    } else {
-      assert.equal(subject.get('encapsulated').last?.value, 56);
-    }
+    assert.equal(subject.get('encapsulated').get('last')?.value, 56);
   });
 });

--- a/tests/unit/last-value-test.ts
+++ b/tests/unit/last-value-test.ts
@@ -41,6 +41,34 @@ module('Unit | last-value', function(hooks) {
     );
   });
 
+  test('without a default value (using wrapper for TS support)', function(assert) {
+    class ObjectWithTask extends EmberObject {
+      @task
+      task = task(function*() {
+        return yield 'foo';
+      });
+
+      @lastValue('task')
+      value?: 'foo';
+    }
+
+    const instance = ObjectWithTask.create();
+    assert.strictEqual(
+      instance.get('value'),
+      undefined,
+      'it returns nothing if the task has not been performed'
+    );
+
+    instance.get('task').perform();
+    nextLoop();
+
+    assert.strictEqual(
+      instance.get('value'),
+      'foo',
+      'returning the last successful value'
+    );
+  });
+
   test('with a default value', function(assert) {
     class ObjectWithTaskDefaultValue extends EmberObject {
       @task
@@ -61,6 +89,35 @@ module('Unit | last-value', function(hooks) {
     );
 
     // @ts-ignore
+    instance.get('task').perform();
+    nextLoop();
+
+    assert.equal(
+      instance.get('value'),
+      'foo',
+      'returning the last successful value'
+    );
+  });
+
+  test('with a default value (using wrapper for TS support)', function(assert) {
+    class ObjectWithTaskDefaultValue extends EmberObject {
+      @task
+      task = task(function*() {
+        return yield 'foo';
+      });
+
+      @lastValue('task')
+      value = 'default value';
+    }
+
+    const instance = ObjectWithTaskDefaultValue.create();
+
+    assert.strictEqual(
+      instance.get('value'),
+      'default value',
+      'it returns the default value if the task has not been performed'
+    );
+
     instance.get('task').perform();
     nextLoop();
 


### PR DESCRIPTION
This is based on #56 now that [types have landed](https://github.com/machty/ember-concurrency/pull/357) in `ember-concurrency`.

The idea is that `task` can act as both a decorator and as a function that wraps a task generator or encapsulated task descriptor. When used as a wrapper, it simply passes through the argument while providing a return type of `Task`. This allows you to interact with the task property exactly as you would in JavaScript, but with the type-safety of TypeScript:

```ts
import { task } from 'ember-concurrency-decorators';

class Foo {
  @task
  myTask = task(function*(arg: string) {
    yield;
    return 100;
  });

  doSomething() {
    this.myTask.perform(); // $ExpectError
    this.myTask.perform(99); // $ExpectError
    this.myTask.perform('Tada!'); // 🎉 
  }

  getVal() {
    const lastVal1: string | null | undefined = this.myTask.last?.value; // $ExpectError
    const lastVal2: number | null | undefined = this.myTask.last?.value; // 🎉 
  }
}
``` 

Note: This is an alternative approach to https://github.com/chancancode/ember-concurrency-ts

@chancancode @dfreeman @chriskrycho @buschtoens 