### PR TITLE
Fix types to allow all options (properly typed)

### DIFF
--- a/addon/index.ts
+++ b/addon/index.ts
@@ -31,10 +31,10 @@ type OptionKeysFor<T extends object> = {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type OptionKeyFor<T, K, F> = F extends (...args: any[]) => T ? K : never;
 
-type OptionTypeFor<T, F> = F extends (...args: []) => T
-  ? true
-  : F extends (arg: infer Arg) => T
-  ? Arg
+type OptionTypeFor<T, F> = F extends (...args: infer Args) => T
+  ? Args[0] extends undefined
+    ? true
+    : Args[0]
   : never;
 
 type TaskOptions = OptionsFor<TaskProperty>;

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -28,7 +28,8 @@ type OptionKeysFor<T extends object> = {
   [K in keyof T]: OptionKeyFor<T, K, T[K]>;
 }[keyof T];
 
-type OptionKeyFor<T, K, F> = F extends (...args: unknown[]) => T ? K : never;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type OptionKeyFor<T, K, F> = F extends (...args: any[]) => T ? K : never;
 
 type OptionTypeFor<T, F> = F extends (...args: []) => T
   ? true

--- a/tests/unit/decorators-test.ts
+++ b/tests/unit/decorators-test.ts
@@ -48,6 +48,24 @@ module('Unit | decorators', function() {
         yield;
         return 34;
       };
+
+      /* eslint-disable @typescript-eslint/no-empty-function */
+
+      @task({ restartable: true }) restartable = function*() {};
+      @task({ enqueue: true }) enqueue = function*() {};
+      @task({ drop: true }) drop = function*() {};
+      @task({ keepLatest: true }) keepLatest = function*() {};
+      @task({ evented: true }) evented = function*() {};
+      @task({ debug: true }) debug = function*() {};
+
+      // Note: these options work even when strictFunctionTypes is enabled, but
+      // turning it on in this repo breaks other things in addon/index.ts
+      @task({ on: 'hi' }) on = function*() {};
+      @task({ cancelOn: 'bye' }) cancelOn = function*() {};
+      @task({ maxConcurrency: 1 }) maxConcurrency = function*() {};
+      @task({ group: 'foo' }) group = function*() {};
+
+      /* eslint-enable @typescript-eslint/no-empty-function */
     }
 
     let subject!: TestSubject;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "noImplicitAny": true,
     "noImplicitThis": true,
     "alwaysStrict": true,
+    "strictFunctionTypes": false,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
There were two problems here:
1. when  a projects has the `strictFunctionTypes` TS compiler option enabled, `...args: unknown[]` is not loose enough to match methods with arguments thus those keys were being excluded
2. the extraction of option types did not handle the variadic options `on` and `cancelOn` and were incorrectly typing them to `true`

The fixes are:
1. widen the type to `...args: any[]` to match any method args.
2. refactor the option type extraction to handle variadic methods (`ember-concurrency-decorators` just allows one value for these so we reduce `Array<T>` to just `T`)

I also added a test for all options (just that it type-checks) but I was not able to enable `strictFunctionTypes` here without blowing up `addon/index.ts`. It will need some work to make that test actually catch problem 1.

@chancancode @nightire @maxfierke @chriskrycho @dfreeman