### PR TITLE
Add ability to specify multiple events

### DIFF
--- a/addon/index.ts
+++ b/addon/index.ts
@@ -34,7 +34,9 @@ type OptionKeyFor<T, K, F> = F extends (...args: any[]) => T ? K : never;
 type OptionTypeFor<T, F> = F extends (...args: infer Args) => T
   ? Args[0] extends undefined
     ? true
-    : Args[0]
+    : Args[1] extends undefined
+    ? Args[0]
+    : Args[0] | Array<Args[0]>
   : never;
 
 type TaskOptions = OptionsFor<TaskProperty>;
@@ -170,6 +172,12 @@ function applyOptions(
       );
       if (value === true) {
         return (taskProperty[key] as () => typeof taskProperty)();
+      }
+      if (Array.isArray(value)) {
+        type O = typeof value[0];
+        return (taskProperty[key] as (...o: O[]) => typeof taskProperty)(
+          ...value
+        );
       }
       return (taskProperty[key] as (o: typeof value) => typeof taskProperty)(
         value

--- a/tests/unit/decorators-test.ts
+++ b/tests/unit/decorators-test.ts
@@ -61,7 +61,11 @@ module('Unit | decorators', function() {
       // Note: these options work even when strictFunctionTypes is enabled, but
       // turning it on in this repo breaks other things in addon/index.ts
       @task({ on: 'hi' }) on = function*() {};
+      @task({ on: ['hi'] }) on1 = function*() {};
+      @task({ on: ['hi', 'there'] }) on2 = function*() {};
       @task({ cancelOn: 'bye' }) cancelOn = function*() {};
+      @task({ cancelOn: ['bye'] }) cancelOn1 = function*() {};
+      @task({ cancelOn: ['bye', 'later'] }) cancelOn2 = function*() {};
       @task({ maxConcurrency: 1 }) maxConcurrency = function*() {};
       @task({ group: 'foo' }) group = function*() {};
 


### PR DESCRIPTION
The [.on()](https://github.com/machty/ember-concurrency/blob/067fb79524b69ba4118765bb709ef93aec4800bc/addon/-task-property.js#L506-L515) and [.cancelOn()](https://github.com/machty/ember-concurrency/blob/067fb79524b69ba4118765bb709ef93aec4800bc/addon/-task-property.js#L524-L533) task modifiers are variadic, accepting a list of trigger events. Currently, ember-concurrency-decorators only allows specifying a single event, e.g
```js
@task({ on: 'start', cancelOn: 'stop' })
```
This PR retains that API and adds the ability to specify multiple events as an array:
```js
@task({ on: 'start', cancelOn: 'stop' }) // existing API is retained

@task({ on: ['start', 'go'], cancelOn: ['stop', 'bye'] }) // can now specify multiple events

@task({ on: ['start'], cancelOn: ['stop'] }) // also valid
```
I have updated the types to only accept an array if the modifier method accepts more than one parameter:

```ts
@task({ drop: [true] }) // type error
@task({ maxConcurrency: [1] }) // type error
@task({ group: ['foo'] }) // type error
```

@chancancode @maxfierke @dfreeman @chriskrycho