### PR TITLE
docs(readme): add lifecycle events example

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,15 @@ You can also pass further options to the task decorator:
 }
 ```
 
+You can also use task lifecycle event hooks in your tasks:
+
+```js
+@task({ on: 'didInsertElement' })
+*doStuff() {
+  // ...
+}
+```
+
 For your convenience, there are extra decorators for all [concurrency modifiers](http://ember-concurrency.com/docs/task-concurrency):
 
 | Shorthand          | Equivalent                     |


### PR DESCRIPTION
As referenced in https://github.com/machty/ember-concurrency-decorators/issues/60
Lifecycle events can still be used, the documentation was simply lacking the reference 😃