### PR TITLE
Fix Edge (legacy) object-spread error (issue #65)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,10 @@
 'use strict';
 
 module.exports = {
-  name: require('./package').name
+  name: require('./package').name,
+  options: {
+    babel: {
+      plugins: [require.resolve('@babel/plugin-proposal-object-rest-spread')]
+    }
+  }
 };

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "ember-cli-typescript": "^3.1.4"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-object-rest-spread": "^7.12.1",
     "@clark/eslint-config-ember": "^1.24.4",
     "@clark/eslint-config-ember-typescript": "^1.24.4",
     "@clark/eslint-config-node": "^1.24.4",


### PR DESCRIPTION
node: v12.18.2
npm: 6.14.7
Microsoft Edge 44.18362.449.0

Fix issue where Edge will not load the page when encountering object-spread operator. 

- Installed @babel/plugin-proposal-object-rest-spread as devDependency
- Add plugin to index.js

build code before:  
![spread-before](https://user-images.githubusercontent.com/52280338/97434078-c339f200-191e-11eb-9368-00bf0a776f50.JPG)

Build code after:
![spread-after](https://user-images.githubusercontent.com/52280338/97434087-c92fd300-191e-11eb-95a7-feb37c613318.JPG)

Tested it using ember-power-select, the error disappears and everything functions properly

ref: #65 
