### PR TITLE
Fix double-calling of TaskProperty methods for decorator options

### DIFF
--- a/addon/index.ts
+++ b/addon/index.ts
@@ -173,9 +173,9 @@ function applyOptions(
 
     if (value === true) {
       (task[key] as () => typeof task)();
+    } else {
+      (task[key] as (o: typeof value) => typeof task)(value);
     }
-
-    (task[key] as (o: typeof value) => typeof task)(value);
   }
 
   // The CP decorator gets executed in `createDecorator`


### PR DESCRIPTION
This fixes a bug introduced in 2.0.2 which inadvertantly removed the short circuiting
after handling a boolean decorator option, resulting in a second call with
the decoration option as a value.

This triggered an assertion on ember-concurrency v2.0.0-rc.1+